### PR TITLE
Comment required manifest component, bump Gradle for security update.

### DIFF
--- a/Sample Code/app/src/main/AndroidManifest.xml
+++ b/Sample Code/app/src/main/AndroidManifest.xml
@@ -54,6 +54,8 @@
         <!-- Required for receiving GEO system pushing. -->
         <service android:name="dji.sdk.sdkmanager.GeoSyncFileService"/>
 
+        <!-- Required for receiving accessory attachment events.
+            This is necessary for product when connecting over USB. -->
         <activity
             android:name="dji.sdk.sdkmanager.DJIAoaControllerActivity"
             android:theme="@android:style/Theme.Translucent" >

--- a/Sample Code/build.gradle
+++ b/Sample Code/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Sample Code/gradle/wrapper/gradle-wrapper.properties
+++ b/Sample Code/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Tue Sep 20 21:55:48 CDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
When integrating with the DJI SDK it wasn't completely obvious that the `DJIAoaControllerActivity` was necessary for forwarding `USB_ACCESSORY_ATTACHED` events back up to SDK internals to complete a USB product connection.

Figured it'd be helpful to others as most critical manifest components are commented.

